### PR TITLE
Ascii encode unicode with Uglify 2.4.9+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,10 @@ uglify = require('uglify-js');
 seleniumWebdriver = require('selenium-webdriver');
 
 sizzleCode = uglify.minify(fs.readFileSync(require.resolve('sizzle'), 'utf8'), {
-  fromString: true
+  fromString: true,
+  output: {
+    ascii_only: true
+  }
 }).code;
 
 addSizzle = function(driver) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "selenium-webdriver": "~2.39.0",
     "sizzle": "~1.1.0",
-    "uglify-js": "~2.4.8",
+    "uglify-js": "~2.4.11",
     "string": "~1.8.0"
   },
   "devDependencies": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,7 +2,12 @@ fs = require 'fs'
 string = require 'string'
 uglify = require 'uglify-js'
 seleniumWebdriver = require 'selenium-webdriver'
-sizzleCode = uglify.minify(fs.readFileSync(require.resolve('sizzle'), 'utf8'), fromString: yes).code
+sizzleCode = uglify.minify(
+  fs.readFileSync(require.resolve('sizzle'), 'utf8')
+  fromString: yes
+  output:
+    ascii_only: true
+).code
 
 addSizzle = (driver) ->
   {get} = driver


### PR DESCRIPTION
Fixes `Fatal error: missing command parameters` executing minified Sizzle through Selenium Server.
