### PR TITLE
Allow chai v3; test more node versions in CI; tests work with NPM 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "4.2"
+  - "0.12"
   - "0.11"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "selenium-webdriver": ">=2.42.0",
-    "chai": ">= 1 < 3"
+    "chai": ">= 1 < 4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   },
   "devDependencies": {
     "coffee-script": "^1.7.1",
-    "chai": "^1.9.0",
+    "chai": "^3.0.0",
     "mocha": "~1.17.0",
     "phantomjs": "^1.9.7-1",
-    "coffee-errors": "^0.8.6"
+    "coffee-errors": "^0.8.6",
+    "selenium-webdriver": "~2.42.0"
   },
   "peerDependencies": {
     "selenium-webdriver": ">=2.42.0",


### PR DESCRIPTION
* Allow chai v3 peer dependency. Fixes reopened https://github.com/goodeggs/chai-webdriver/issues/25 and https://github.com/goodeggs/chai-webdriver/issues/28.
* Test more node versions (0.12, 4) on Travis.
* Specify peer dependencies as dev dependencies as well, otherwise tests fail to run on node >= 4, because NPM 3 doesn't automatically install peer dependencies.  (Unfortunately, selenium-webdriver does not follow semver and has various breaking changes that depend on the version of node used, so I've also locked that in to 2.42 exactly.)

cc @demands