### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ chai.expect('#site-container h1.heading').dom.to.not.contain.text("I'm a kitty!"
 so easy.
 
 ```bash
-npm install           # download the neccesary development dependencies
+npm install           # download the necessary development dependencies
 npm run-script build  # compile coffee-script into javascript
 npm test              # build and run the specs
 ```


### PR DESCRIPTION
Fixed typo in README: `neccesary` => `necessary`.